### PR TITLE
fix: fields 'size' and 'hasAttachments' not returned to client

### DIFF
--- a/descriptions/rest-api-email-0/rest-api-email-0.json
+++ b/descriptions/rest-api-email-0/rest-api-email-0.json
@@ -748,6 +748,12 @@
                             },
                             "messageId": {
                                 "type": "string"
+                            },
+                            "size": {
+                                "type": "integer"
+                            },
+                            "hasAttachments": {
+                                "type": "boolean"
                             }
                         },
                         "required": [


### PR DESCRIPTION
made sure the api description lists these fields in MessageItem entity

refs conjoon/php-ms-imapuser#43